### PR TITLE
Add get_task_logger info

### DIFF
--- a/lang/en/checklist.md
+++ b/lang/en/checklist.md
@@ -53,7 +53,7 @@ def my_task():
 
 ## Monitoring & Tests
 
-- [ ] Log as much as possible.
+- [ ] Log as much as possible. Use `get_task_logger` to automatically get the task name and unique id as part of the logs.
 - [ ] In case of failure, make sure stack traces get logged and people get notified (services like [Sentry](https://sentry.io) are a good idea).
 - [ ] Monitor activity using Flower. [(Flower: Real-time Celery web-monitor)](http://docs.celeryproject.org/en/latest/userguide/monitoring.html#flower-real-time-celery-web-monitor)
 - [ ] Use `task_always_eager` to test your tasks are geting called.

--- a/lang/ko-kr/checklist.md
+++ b/lang/ko-kr/checklist.md
@@ -57,7 +57,7 @@ def my_task():
 
 ## Monitoring & Tests
 
-- [ ] 가능한 한 더 많은 로그를 남기세요. 
+- [ ] 가능한 한 더 많은 로그를 남기세요. `get_task_logger`를 이용해서 태스크 이름과 고유 id를 자동으로 가져오세요.
 - [ ] 실패했을 때 stack trace를 남기고 사람이 알 수 있도록 하세요. ([Sentry](https://sentry.io) 같은 서비스를 쓰는게 좋아요) 
 - [ ] [Flower: Real-time Celery web-monitor](http://docs.celeryproject.org/en/latest/userguide/monitoring.html#flower-real-time-celery-web-monitor)를 사용해서 샐러리 모니터링을 하세요. 
 - [ ] 태스크 호출을 테스트할 때 `task_always_eager`를 사용하세요.

--- a/lang/pt-br/checklist.md
+++ b/lang/pt-br/checklist.md
@@ -54,7 +54,7 @@ def my_task():
 
 ## Monitoração & Testes
 
-- [ ] Faça logging na medida do possível.
+- [ ] Faça logging na medida do possível. Use `get_task_logger` para automaticamente adicionar o nome e o id único da sua task aos logs.
 - [ ] No caso de falha, tenha certeza de que os traços de pilha (stack traces) tenham logs e que pessoas sejam notificadas (serviços como [Sentry](https://sentry.io) é uma boa idéia).
 - [ ] Monitore atividades usando Flower. [(Flower: Real-time Celery web-monitor)](http://docs.celeryproject.org/en/latest/userguide/monitoring.html#flower-real-time-celery-web-monitor)
 - [ ] Use `task_aways_eager` para testar suas tarefas que estão sendo chamadas.


### PR DESCRIPTION
It's a good practice to log your tasks with the `celery.task` logger. 