### PR TITLE
typo fix

### DIFF
--- a/lang/en/checklist.md
+++ b/lang/en/checklist.md
@@ -37,7 +37,7 @@ raise self.retry(exc=e, countdown=exponential_backoff(self))
 ```
 - [ ] Use [`autoretry_for`](http://docs.celeryproject.org/en/master/userguide/tasks.html#automatic-retry-for-known-exceptions) to reduce the boilerplate code for retrying tasks. 
 - [ ] Use [`retry_backoff`](http://docs.celeryproject.org/en/master/userguide/tasks.html#Task.retry_backoff) to reduce the boilerplate code when doing exponention backoff.
-- [ ] For tasks that require high level of reliability, use `acks_late` in combination with `retry`. Again, make sure taks are idempotent and atomic. [(Should I use retry or acks_late?)](http://docs.celeryproject.org/en/latest/faq.html#faq-acks-late-vs-retry)
+- [ ] For tasks that require high level of reliability, use `acks_late` in combination with `retry`. Again, make sure tasks are idempotent and atomic. [(Should I use retry or acks_late?)](http://docs.celeryproject.org/en/latest/faq.html#faq-acks-late-vs-retry)
 - [ ] Set hard and soft time limits. Recover gracefully if things take longer than expected.
 ```
 from celery.exceptions import SoftTimeLimitExceeded


### PR DESCRIPTION
Fixed `taks` to `tasks`